### PR TITLE
Add scripts for creating, migrating, and seeding db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ dist/
 #keys
 keys.js
 
+#mysql config
+config.txt

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Reviews Module",
+  "name": "",
   "version": "",
   "description": "This is the module on an ecommerce page that shows reviews of the store",
   "author": "",
@@ -8,7 +8,11 @@
     "node": ">=6.13.0"
   },
   "scripts": {
-    "react-dev": "webpack -d --watch"
+    "react-dev": "webpack -d --watch",
+    "create-db": "mysql  --defaults-extra-file=./config.txt < schema.sql",
+    "migrations": "node_modules/.bin/knex migrate:latest",
+    "seed": "node_modules/.bin/knex seed:run",
+    "seed-db": "npm run create-db && npm run migrations && npm run seed"
   },
   "dependencies": {
     "faker": "^4.1.0",


### PR DESCRIPTION
This branch adds my db seeding steps in script form. To perform all necessary steps at once:

```npm run seed-db```